### PR TITLE
fix: Use collectionKey to target correct energy cards

### DIFF
--- a/src/energy-period-selector-plus-base.ts
+++ b/src/energy-period-selector-plus-base.ts
@@ -293,7 +293,9 @@ export class EnergyPeriodSelectorBase extends SubscribeMixin(LitElement) {
         ? endOfDay(customEndDate)
         : this._endDate || endOfToday();
 
-    const energyCollection = getEnergyDataCollection(this.hass);
+    const energyCollection = getEnergyDataCollection(this.hass, {
+      key: this.collectionKey,
+    });
     energyCollection.setPeriod(startDate, endDate);
     energyCollection.refresh();
   }
@@ -319,7 +321,9 @@ export class EnergyPeriodSelectorBase extends SubscribeMixin(LitElement) {
 
   private _toggleCompare() {
     this._compare = !this._compare;
-    const energyCollection = getEnergyDataCollection(this.hass);
+    const energyCollection = getEnergyDataCollection(this.hass, {
+      key: this.collectionKey,
+    });
     energyCollection.setCompare(this._compare);
     energyCollection.refresh();
   }

--- a/src/energy-period-selector-plus.ts
+++ b/src/energy-period-selector-plus.ts
@@ -40,7 +40,7 @@ export class EnergyPeriodSelectorPlus extends LitElement implements LovelaceCard
       logError(localize('common.invalid_configuration') || 'Invalid configuration');
       return nothing;
     }
-    const energyPeriodSelectorBase = html` <energy-period-selector-base .hass=${this.hass} ._config=${this._config}></energy-period-selector-base> `;
+    const energyPeriodSelectorBase = html` <energy-period-selector-base .hass=${this.hass} ._config=${this._config} .collectionKey=${this._config?.collection_key}></energy-period-selector-base> `;
     return this._config?.card_background
       ? html` <ha-card .header=${this._config?.title}> ${energyPeriodSelectorBase}</ha-card> `
       : html` ${energyPeriodSelectorBase} `;

--- a/src/energy/index.ts
+++ b/src/energy/index.ts
@@ -379,9 +379,11 @@ const getEnergyData = async (hass: HomeAssistant, prefs: EnergyPreferences, star
 
   const _energyStats: Statistics | Promise<Statistics> = energyStatIds.length
     ? fetchStatistics(hass!, startMinHour, end, energyStatIds, period, energyUnits, ['sum'])
+    ? fetchStatistics(hass!, startMinHour, end, energyStatIds, period, energyUnits, ['change'])
     : {};
   const _waterStats: Statistics | Promise<Statistics> = waterStatIds.length
     ? fetchStatistics(hass!, startMinHour, end, waterStatIds, period, waterUnits, ['sum'])
+    ? fetchStatistics(hass!, startMinHour, end, waterStatIds, period, waterUnits, ['change'])
     : {};
 
   let statsCompare;

--- a/src/energy/index.ts
+++ b/src/energy/index.ts
@@ -378,11 +378,9 @@ const getEnergyData = async (hass: HomeAssistant, prefs: EnergyPreferences, star
   };
 
   const _energyStats: Statistics | Promise<Statistics> = energyStatIds.length
-    ? fetchStatistics(hass!, startMinHour, end, energyStatIds, period, energyUnits, ['sum'])
     ? fetchStatistics(hass!, startMinHour, end, energyStatIds, period, energyUnits, ['change'])
     : {};
   const _waterStats: Statistics | Promise<Statistics> = waterStatIds.length
-    ? fetchStatistics(hass!, startMinHour, end, waterStatIds, period, waterUnits, ['sum'])
     ? fetchStatistics(hass!, startMinHour, end, waterStatIds, period, waterUnits, ['change'])
     : {};
 

--- a/src/energy/recorder.ts
+++ b/src/energy/recorder.ts
@@ -97,7 +97,7 @@ export interface StatisticsUnitConfiguration {
   volume?: 'L' | 'gal' | 'ft³' | 'm³';
 }
 
-const statisticTypes = ['last_reset', 'max', 'mean', 'min', 'state', 'sum'] as const;
+const statisticTypes = ['last_reset', 'max', 'mean', 'min', 'state', 'sum', 'change'] as const;
 export type StatisticsTypes = (typeof statisticTypes)[number][];
 
 export interface StatisticsValidationResults {


### PR DESCRIPTION
While attempting to fix empty graphs getting rendered ( a couple of issues open about that), I noticed the collectionKey is not correctly being set and send when loading data.
When I set `collection_key` property on both the stock energy cards and this custom one, all graphs start rendering correctly again, however, the data does not change when changing selected periods.
Setting these values should result in data being loaded correctly.